### PR TITLE
Add Drupal admin navigation layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 .nova
 dist
 .DS_Store
+node-compile-cache

--- a/layers/drupal-admin/README.md
+++ b/layers/drupal-admin/README.md
@@ -1,0 +1,68 @@
+# Drupal Admin Layer
+
+A Nuxt layer that ships Drupal-aware navigation primitives (including `DrupalTabs`) backed by `nuxtjs-drupal-ce` and Nuxt UI.
+You can use it directly from this repository (as a Nuxt layer path) or install it as an npm/git dependency that you extend from
+your own Nuxt app.
+
+## Installation
+
+Add the layer to your project and extend it in `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  extends: ['@your-scope/drupal-admin-layer'],
+})
+```
+
+Or reference this repository directly (mirroring the base layer pattern) on the admin branch:
+
+```ts
+export default defineNuxtConfig({
+  extends: ['github:StirStudios/nuxtjs-drupal-stir#release/nuxtjs-drupal-stir-admin'],
+})
+```
+
+You can also consume it directly from this repository without publishing by pointing Nuxt at the layer path:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  extends: ['./layers/drupal-admin'],
+})
+```
+
+Ensure the host project installs the peer dependencies:
+
+- `nuxt@^4.2.1`
+- `@nuxt/ui@^4.2.1`
+- `nuxtjs-drupal-ce@^2.5.0-rc.6`
+
+## Runtime configuration
+
+Set the Drupal base URL so the "Drupal CMS" link in `DrupalTabs` resolves correctly:
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  runtimeConfig: {
+    public: {
+      api: 'https://your-drupal-host',
+    },
+  },
+})
+```
+
+## Provided APIs
+
+- `app/components/Drupal/DrupalTabs.vue`: auto-imported navigation tabs powered by Nuxt UI's `UNavigationMenu`.
+- `app/composables/usePageContext.ts`: exposes the current page payload (including `page`, `current_user`, and `local_tasks`).
+- `app/composables/useDrupalCe.ts`: re-export of `nuxtjs-drupal-ce` composables so you can call
+  `useDrupalCe().fetchMenu('account')` inside the component or your own code.
+
+### Expected page payload
+
+`DrupalTabs` relies on the Drupal CE payload structure. Ensure your rendered page data provides:
+
+- `local_tasks.primary` and `local_tasks.secondary` arrays for contextual tabs.
+- `current_user.name` (and optional `current_user.roles`).
+- An account menu available via `useDrupalCe().fetchMenu('account')`.

--- a/layers/drupal-admin/app/components/Drupal/DrupalTabs.vue
+++ b/layers/drupal-admin/app/components/Drupal/DrupalTabs.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { usePageContext } from '~/composables/usePageContext'
+
+const { page } = usePageContext()
+const config = useRuntimeConfig()
+const siteApi = config.public.api
+const { fetchMenu } = useDrupalCe()
+
+const accountMenu = ref([])
+
+const tabs = computed(
+  () => page.value?.local_tasks ?? { primary: [], secondary: [] },
+)
+const user = computed(() => page.value?.current_user)
+
+const getIconForLabel = (label: string): string | null => {
+  const iconMap: Record<string, string> = {
+    'Drupal CMS': 'i-lucide-home',
+    Settings: 'i-lucide-settings',
+    View: 'i-lucide-eye',
+    Edit: 'i-lucide-pencil',
+    Delete: 'i-lucide-trash-2',
+    Revisions: 'i-lucide-copy',
+    Export: 'i-lucide-upload',
+    API: 'i-lucide-code',
+    'Log out': 'i-lucide-log-out',
+    'Log in': 'i-lucide-log-in',
+    'My account': 'i-lucide-user',
+  }
+
+  return iconMap[label] || null
+}
+
+// Safe, clean async call with fallback
+try {
+  const rawMenu = await fetchMenu('account')
+  accountMenu.value = Array.isArray(rawMenu.value)
+    ? rawMenu.value.map((item) => ({
+        label: item.title,
+        to: item.relative || item.url,
+        icon: getIconForLabel(item.title),
+      }))
+    : []
+} catch (e) {
+  console.error('Failed to fetch account menu:', e)
+}
+
+// Optional: helper to map local tasks
+const getLocalTaskLinks = () =>
+  tabs.value.primary.map((tab) => ({
+    label: tab.label,
+    to: tab.url,
+    icon: getIconForLabel(tab.label),
+  }))
+
+// Dynamic nav links
+const links = computed(() => {
+  const baseLinks = [
+    [
+      {
+        label: 'Drupal CMS',
+        icon: getIconForLabel('Drupal CMS'),
+        to: `${siteApi}/admin/content`,
+        target: '_self',
+      },
+    ],
+  ]
+
+  const localTaskLinks = tabs.value.primary?.length ? [getLocalTaskLinks()] : []
+
+  const accountDropdown = [
+    {
+      label: user.value?.name || 'Account',
+      icon: getIconForLabel('My account'),
+      children: accountMenu.value,
+    },
+  ]
+
+  return [...baseLinks, ...localTaskLinks, accountDropdown]
+})
+</script>
+
+<template>
+  <UNavigationMenu
+    content-orientation="vertical"
+    highlight
+    highlight-color="primary"
+    :items="links"
+    :ui="{
+      root: 'sticky top-0 z-60 h-[3.1rem] w-full bg-neutral-200 dark:bg-neutral-900 p-4 shadow',
+      link: 'text-xs text-black dark:text-white',
+      linkLabel: 'hidden md:block',
+      linkLeadingIcon: 'text-black dark:text-white',
+    }"
+  />
+</template>

--- a/layers/drupal-admin/app/composables/useDrupalCe.ts
+++ b/layers/drupal-admin/app/composables/useDrupalCe.ts
@@ -1,0 +1,1 @@
+export { useDrupalCe } from 'nuxtjs-drupal-ce/dist/runtime/composables/useDrupalCe'

--- a/layers/drupal-admin/app/composables/usePageContext.ts
+++ b/layers/drupal-admin/app/composables/usePageContext.ts
@@ -1,0 +1,53 @@
+export function usePageContext() {
+  const nuxtApp = useNuxtApp()
+  const route = useRoute()
+
+  const currentKey = useState<string>('drupal-ce-current-page-key', () => '')
+  const page = computed(() => nuxtApp.payload?.data?.[currentKey.value])
+
+  // Reactive + safe slug
+  const slug = computed(() => {
+    const p = route.params.slug
+    return Array.isArray(p) ? p[0] : p || null
+  })
+
+  const isFront = computed(() => route.path === '/')
+
+  const isAdministrator = computed(
+    () => page.value?.current_user?.roles?.includes('administrator') || false,
+  )
+
+  // Element and metadata
+  const pageElement = computed(() => page.value?.content?.element || '')
+
+  // Page props
+  const pageProps = computed(() => page.value?.content?.props || {})
+
+  // Safe title access for hero + meta
+  const pageTitle = computed(() => pageProps.value?.title || '')
+  const pageCreated = computed(() => pageProps.value?.created || '')
+  const pageHide = computed(() => pageProps.value?.hide || false)
+  const pageLayout = computed(() => page.value?.page_layout || '')
+
+  const bodyClasses = computed(() =>
+    [
+      slug.value || 'front',
+      isAdministrator.value ? 'logged-in' : '',
+      pageElement.value,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  )
+
+  return {
+    page,
+    slug,
+    isFront,
+    isAdministrator,
+    bodyClasses,
+    pageTitle,
+    pageCreated,
+    pageHide,
+    pageLayout,
+  }
+}

--- a/layers/drupal-admin/nuxt.config.ts
+++ b/layers/drupal-admin/nuxt.config.ts
@@ -1,0 +1,10 @@
+export default defineNuxtConfig({
+  compatibilityDate: '2025-11-23',
+  modules: ['@nuxt/ui', 'nuxtjs-drupal-ce'],
+  components: [{ path: '~/components', pathPrefix: false, global: true }],
+  runtimeConfig: {
+    public: {
+      api: '',
+    },
+  },
+})

--- a/layers/drupal-admin/package.json
+++ b/layers/drupal-admin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@your-scope/drupal-admin-layer",
+  "version": "0.1.0",
+  "description": "Nuxt layer that exposes Drupal admin navigation primitives.",
+  "type": "module",
+  "exports": "./nuxt.config.ts",
+  "files": [
+    "app",
+    "nuxt.config.ts",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "nuxt": "^4.2.1",
+    "@nuxt/ui": "^4.2.1",
+    "nuxtjs-drupal-ce": "^2.5.0-rc.6"
+  }
+}


### PR DESCRIPTION
## Summary
- add Drupal admin layer with tabs component and supporting composables
- document installation, runtime configuration, and provided APIs
- update .gitignore to exclude node-compile-cache

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e44ff7088832982b7425c5c683076)