### PR TITLE
Document admin layer setup and playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ your own Nuxt app.
 
 ## Installation
 
-Add the layer to your project and extend it in `nuxt.config.ts`:
+Add the layer to your project as a git dependency so the bundled Nuxt UI and Tailwind
+packages are resolved from the layer:
+
+```json
+// package.json
+{
+  "dependencies": {
+    "@stir/admin": "github:StirStudios/nuxtjs-drupal-stir#release/nuxtjs-drupal-stir-admin"
+  }
+}
+```
+
+Then extend the layer in `nuxt.config.ts`:
 
 ```ts
 export default defineNuxtConfig({
@@ -33,3 +45,49 @@ modules correctly.
 - `local_tasks.primary` and `local_tasks.secondary` arrays for contextual tabs.
 - `current_user.name` (and optional `current_user.roles`).
 - An account menu available via `useDrupalCe().fetchMenu('account')`.
+
+## Using with Drupal CE scaffolding
+
+When initializing a Nuxt app with `nuxtjs-drupal-ce`, scaffold the starter files and remove
+the default `app.vue` so the layer can supply its own layout:
+
+```bash
+rm -f app.vue && npx nuxt-drupal-ce-init
+```
+
+After scaffolding, delete the local `<DrupalTabs />` component reference and rely on the
+lazy-loaded version from this layer in your default layout:
+
+```vue
+<template>
+  <div>
+    <LazyDrupalTabs />
+    <header>
+      <SiteLanguageSwitcher v-if="useNuxtApp().$i18n" />
+      <NavigationMain />
+    </header>
+    <SiteMessages />
+    <main id="main">
+      <slot />
+    </main>
+    <footer>
+      <NavigationAccount />
+    </footer>
+  </div>
+</template>
+
+<style>
+#main {
+  min-height: 70vh;
+}
+body {
+  background-color: white;
+}
+</style>
+```
+
+## Playground
+
+A Nuxt playground is included under `playground/` for quick testing of the layer in
+isolation. Install dependencies and run `pnpm dev` (or your preferred package manager)
+from that directory to experiment with the admin menu and tabs locally.


### PR DESCRIPTION
## Summary
- document installing the admin layer via git dependency and extending in Nuxt config
- add Drupal CE scaffolding guidance, including replacing local DrupalTabs usage
- mention included playground for local testing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311771d48c83299eb994469b606947)