### PR TITLE
Fix footer section defaults

### DIFF
--- a/layers/theme/app/app.config.ts
+++ b/layers/theme/app/app.config.ts
@@ -139,11 +139,6 @@ export default defineAppConfig({
       content: 'flex flex-col items-center justify-center gap-4 text-center',
       left: 'mt-8 text-sm leading-relaxed lg:mt-0 lg:text-left',
       right: 'flex flex-col items-center gap-2 lg:items-end lg:text-right',
-      sections: {
-        left: ['logo'],
-        center: ['menu', 'legal'],
-        right: ['socials', 'email'],
-      },
       actions: [],
       action: '',
       actionsWrapper: '',

--- a/layers/theme/app/components/App/Footer.vue
+++ b/layers/theme/app/components/App/Footer.vue
@@ -41,6 +41,11 @@ const toStringArray = (value: unknown): string[] | undefined => {
 
   return items.length ? items : undefined
 }
+const toSectionAtoms = (value: unknown): string[] | undefined => {
+  const items = toStringArray(value)
+
+  return items?.filter((item, index) => items.indexOf(item) === index)
+}
 
 const footerConfig = computed(() => theme.footer)
 const footerLayout = computed(() => toFooterLayout(footerConfig.value.layout))
@@ -66,15 +71,15 @@ const footerSections = computed<Required<FooterSections>>(() => {
   if (footerLayout.value === 'stacked') {
     return {
       left: [],
-      center: toStringArray(configured.center) || ['actions', 'menu', 'socials', 'legal'],
+      center: toSectionAtoms(configured.center) || ['actions', 'menu', 'socials', 'legal'],
       right: [],
     }
   }
 
   return {
-    left: toStringArray(configured.left) || ['logo'],
-    center: toStringArray(configured.center) || ['menu', 'legal'],
-    right: toStringArray(configured.right) || ['socials', 'email'],
+    left: toSectionAtoms(configured.left) || ['logo'],
+    center: toSectionAtoms(configured.center) || ['menu', 'legal'],
+    right: toSectionAtoms(configured.right) || ['socials', 'email'],
   }
 })
 const footerClasses = computed(() => ({


### PR DESCRIPTION
## Summary
- Move default footer section atoms out of app config and rely on layout-aware fallbacks in the footer component
- De-duplicate configured footer section atoms to avoid Nuxt config array merge duplication

## Checks
- pnpm lint
- pnpm typecheck