### PR TITLE
Add generic article sharing

### DIFF
--- a/layers/theme/app/components/Drupal/NodeDisplay.vue
+++ b/layers/theme/app/components/Drupal/NodeDisplay.vue
@@ -29,11 +29,12 @@ defineOptions({
 const { pageLayout } = usePageContext()
 const slots = useSlots()
 const teaser = useNodeTeaser(slots)
+const isArticle = computed(() => resolveBooleanProp(props.isArticle))
 const renderMode = computed<'teaser' | 'article' | 'default'>(() => {
   const type = props.type || ''
 
   if (props.teaserModes.some((mode) => type.includes(mode))) return 'teaser'
-  if (props.isArticle) return 'article'
+  if (isArticle.value) return 'article'
 
   return 'default'
 })
@@ -120,6 +121,14 @@ provideRevealMotionScope(
   />
 
   <article v-else-if="renderMode === 'article'">
+    <UContainer class="flex justify-end py-4">
+      <ShareLinks
+        :description="props.summary"
+        :title="props.title"
+        variant="menu"
+      />
+    </UContainer>
+
     <template v-for="slotName in contentSlotNames" :key="slotName">
       <slot :name="slotName" />
     </template>

--- a/layers/theme/app/types/Node.ts
+++ b/layers/theme/app/types/Node.ts
@@ -12,6 +12,7 @@ export interface DrupalNodeRelatedItem {
 
 export interface NodeCommonProps {
   title: string
+  summary?: string
   url?: string
   type?: string
   isArticle?: boolean | string

--- a/tests/utils/nodeOverrideContract.spec.ts
+++ b/tests/utils/nodeOverrideContract.spec.ts
@@ -20,10 +20,14 @@ describe('node override contract', () => {
     expect(nodeDisplay).toContain('\'default\', \'uid\'')
     expect(nodeDisplay).toContain('v-if="renderMode !== \'teaser\'"')
     expect(nodeDisplay).toContain(':link="props.editLink"')
+    expect(nodeDisplay).toContain('resolveBooleanProp(props.isArticle)')
+    expect(nodeDisplay).toContain('<ShareLinks')
+    expect(nodeDisplay).toContain(':title="props.title"')
 
     const nodeTypes = source('layers/theme/app/types/Node.ts')
 
     expect(nodeTypes).toContain('url?: string')
+    expect(nodeTypes).toContain('summary?: string')
   })
 
   it('uses the accessible default layout when Drupal omits page_layout', () => {


### PR DESCRIPTION
Adds content-type-agnostic article sharing to the shared node renderer, fixes boolean article-mode handling, and extends the node contract with an optional summary.\n\nValidated with ESLint, Nuxt typecheck, and 466 Vitest tests.