### PR TITLE
Contain default article content

### DIFF
--- a/layers/theme/app/components/Drupal/NodeDisplay.vue
+++ b/layers/theme/app/components/Drupal/NodeDisplay.vue
@@ -121,17 +121,19 @@ provideRevealMotionScope(
   />
 
   <article v-else-if="renderMode === 'article'">
-    <UContainer class="flex justify-end py-4">
-      <ShareLinks
-        :description="props.summary"
-        :title="props.title"
-        variant="menu"
-      />
-    </UContainer>
+    <UContainer>
+      <div class="flex justify-end py-4">
+        <ShareLinks
+          :description="props.summary"
+          :title="props.title"
+          variant="menu"
+        />
+      </div>
 
-    <template v-for="slotName in contentSlotNames" :key="slotName">
-      <slot :name="slotName" />
-    </template>
+      <template v-for="slotName in contentSlotNames" :key="slotName">
+        <slot :name="slotName" />
+      </template>
+    </UContainer>
   </article>
 
   <slot

--- a/tests/utils/nodeOverrideContract.spec.ts
+++ b/tests/utils/nodeOverrideContract.spec.ts
@@ -23,6 +23,9 @@ describe('node override contract', () => {
     expect(nodeDisplay).toContain('resolveBooleanProp(props.isArticle)')
     expect(nodeDisplay).toContain('<ShareLinks')
     expect(nodeDisplay).toContain(':title="props.title"')
+    expect(nodeDisplay).toMatch(
+      /<article v-else-if="renderMode === 'article'">\s*<UContainer>/,
+    )
 
     const nodeTypes = source('layers/theme/app/types/Node.ts')
 


### PR DESCRIPTION
Wraps the generic article presentation in the shared Nuxt UI container so ordinary article fields have consistent responsive gutters and max width. The existing article slot remains the explicit escape hatch for custom or full-width editorial layouts. Includes a focused renderer contract assertion.