### PR TITLE
Avoid empty front-page Hero subtitle headings

### DIFF
--- a/layers/theme/app/components/HeroContent.vue
+++ b/layers/theme/app/components/HeroContent.vue
@@ -24,7 +24,7 @@ defineSlots<{ button?(): unknown }>()
 <template>
   <template v-if="pageTitle && isFront">
     <h1>{{ pageTitle }}</h1>
-    <h2 class="display-h1 text-left">{{ subtitle }}</h2>
+    <h2 v-if="subtitle" class="display-h1 text-left">{{ subtitle }}</h2>
   </template>
 
   <h1 v-else-if="pageTitle" class="mb-0 text-white">

--- a/tests/utils/heroMotionAccessibility.spec.ts
+++ b/tests/utils/heroMotionAccessibility.spec.ts
@@ -9,6 +9,13 @@ const heroSource = readFileSync(
   ),
   'utf8',
 )
+const heroContentSource = readFileSync(
+  resolve(
+    process.cwd(),
+    'layers/theme/app/components/HeroContent.vue',
+  ),
+  'utf8',
+)
 const pageRouteSource = readFileSync(
   resolve(
     process.cwd(),
@@ -28,6 +35,10 @@ describe('hero reveal accessibility', () => {
   it('keeps explicitly animated hero content visible with reduced motion', () => {
     expect(heroSource).toContain('motion-reduce:!opacity-100')
     expect(heroSource).toContain('motion-reduce:!transform-none')
+  })
+
+  it('does not render an empty subtitle heading', () => {
+    expect(heroContentSource).toContain('<h2 v-if="subtitle"')
   })
 
   it('uses an SSR entrance animation instead of a viewport reveal', () => {


### PR DESCRIPTION
## Summary\n- render the front-page Hero subtitle only when content exists\n- preserve the single H1 plus lead-copy hierarchy for subtitle-free heroes\n- add a semantic regression test\n\n## Verification\n- 86 test files / 467 tests\n- ESLint\n- Nuxt typecheck