### PR TITLE
Render paragraph card surfaces with Nuxt UI

### DIFF
--- a/docs/stir-theme-config.md
+++ b/docs/stir-theme-config.md
@@ -404,6 +404,13 @@ frontPage: {
 container: 'max-w-(--ui-container) mx-auto px-4 md:px-5 lg:px-8',
 ```
 
+When Drupal enables **Card** on a Layout paragraph, the grid is rendered with
+Nuxt UI `UCard`. The existing `stirTheme.card` classes and optional Drupal
+gradient remain the branded layout surface. When **Card** is enabled on a Text
+paragraph, the text is rendered in a standard `UCard`, so projects can theme
+that reusable surface through Nuxt UI's global `ui.card` configuration. With
+Card disabled, both paragraph renderers retain their existing minimal markup.
+
 ### 🪟 `overlay`
 
 Use this to control Nuxt UI overlay portal behavior for popovers, modals, and select menus.
@@ -655,6 +662,10 @@ gradients: {
   3: 'bg-gradient-to-b from-[#7b2ff7] to-[#e53e3e]',
 },
 ```
+
+These `stirTheme.card` values apply to Layout cards. Standard Text cards use
+Nuxt UI's semantic card tokens and therefore follow the surrounding color mode
+and the project's global `ui.card` overrides.
 
 ### 🖼️ Carousel (StirTheme)
 

--- a/docs/vnext/current-inventory.json
+++ b/docs/vnext/current-inventory.json
@@ -710,11 +710,11 @@
     "serverRoutes": 27,
     "productionDependencies": 44,
     "developmentDependencies": 27,
-    "tests": 130,
+    "tests": 131,
     "testsByArea": {
       "composables": 12,
       "contracts": 1,
-      "nuxt": 44,
+      "nuxt": 45,
       "server": 24,
       "unit": 8,
       "utils": 41
@@ -761,6 +761,7 @@
     "tests/nuxt/runtime/ParagraphFeature.nuxt.spec.ts",
     "tests/nuxt/runtime/ParagraphLayout.nuxt.spec.ts",
     "tests/nuxt/runtime/ParagraphRevealTargets.nuxt.spec.ts",
+    "tests/nuxt/runtime/ParagraphTextCard.nuxt.spec.ts",
     "tests/nuxt/runtime/RegionAreaAppContext.nuxt.spec.ts",
     "tests/nuxt/runtime/Relocated.nuxt.spec.ts",
     "tests/nuxt/runtime/RevealMotion.nuxt.spec.ts",

--- a/layers/theme/app/components/Wrap/Grid.vue
+++ b/layers/theme/app/components/Wrap/Grid.vue
@@ -21,12 +21,15 @@ const gridStyles = computed(() => {
 
 const contentWrapperClasses = computed(() => {
   return [
-    props.card ? themeCard.base : null,
     props.classes || null,
     props.width || null,
     props.spacing || null,
   ].filter((value): value is string => typeof value === 'string' && value.length > 0)
 })
+const cardUi = computed(() => ({
+  root: themeCard.base,
+  body: 'p-0 sm:p-0',
+}))
 const combinedClasses = computed(() => [
   props.container ? themeContainer : null,
   ...contentWrapperClasses.value,
@@ -36,19 +39,28 @@ const combinedClasses = computed(() => [
 
 <template>
   <WrapDiv v-if="props.card && props.container" :styles="themeContainer">
-    <WrapDiv :styles="contentWrapperClasses">
+    <UCard
+      :class="contentWrapperClasses"
+      :ui="cardUi"
+      variant="solid"
+    >
       <WrapDiv :styles="gridStyles">
         <slot />
       </WrapDiv>
       <LazyCardGradient :layout="props" />
-    </WrapDiv>
+    </UCard>
   </WrapDiv>
-  <WrapDiv v-else-if="props.card" :styles="contentWrapperClasses">
+  <UCard
+    v-else-if="props.card"
+    :class="contentWrapperClasses"
+    :ui="cardUi"
+    variant="solid"
+  >
     <WrapDiv :styles="gridStyles">
       <slot />
     </WrapDiv>
     <LazyCardGradient :layout="props" />
-  </WrapDiv>
+  </UCard>
   <WrapDiv v-else :styles="combinedClasses">
     <slot />
   </WrapDiv>

--- a/layers/theme/app/components/global/Paragraph/Text.vue
+++ b/layers/theme/app/components/global/Paragraph/Text.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { EditableRichTextProps } from '#stir/types'
+import { resolveBooleanProp } from '#stir/utils/nuxtUiProps'
 
 defineOptions({
   inheritAttrs: false,
@@ -8,6 +9,7 @@ defineOptions({
 const props = defineProps<
   EditableRichTextProps & {
     align?: string
+    card?: boolean | string | number
     width?: string
     spacing?: string
     region?: string
@@ -31,10 +33,14 @@ const wrapStyles = computed(() =>
     (value): value is string => typeof value === 'string' && value.length > 0,
   ),
 )
+const isCard = computed(() => resolveBooleanProp(props.card))
 </script>
 
 <template>
   <WrapDiv :align="align" :styles="wrapStyles">
-    <EditableRichText v-bind="richTextProps" />
+    <UCard v-if="isCard" class="h-full">
+      <EditableRichText v-bind="richTextProps" />
+    </UCard>
+    <EditableRichText v-else v-bind="richTextProps" />
   </WrapDiv>
 </template>

--- a/tests/nuxt/runtime/ParagraphTextCard.nuxt.spec.ts
+++ b/tests/nuxt/runtime/ParagraphTextCard.nuxt.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import ParagraphText from '../../../layers/theme/app/components/global/Paragraph/Text.vue'
+
+describe('ParagraphText card presentation', () => {
+  it('preserves the minimal rich-text markup by default', async () => {
+    const wrapper = await mountSuspended(ParagraphText, {
+      props: {
+        text: '<p>Direct text</p>',
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'UCard' }).exists()).toBe(false)
+    expect(wrapper.text()).toContain('Direct text')
+  })
+
+  it('uses the shared Nuxt UI card when enabled', async () => {
+    const wrapper = await mountSuspended(ParagraphText, {
+      props: {
+        card: true,
+        text: '<p>Card text</p>',
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'UCard' }).exists()).toBe(true)
+    expect(wrapper.text()).toContain('Card text')
+  })
+})

--- a/tests/nuxt/runtime/WrapGrid.nuxt.spec.ts
+++ b/tests/nuxt/runtime/WrapGrid.nuxt.spec.ts
@@ -54,7 +54,8 @@ describe('WrapGrid (Nuxt runtime)', () => {
 
     expect(inner?.classList.contains('grid')).toBe(true)
     expect(inner?.classList.contains('relative')).toBe(true)
-    expect(outer?.classList.contains('isolate')).toBe(true)
+    expect(outer?.parentElement?.classList.contains('isolate')).toBe(true)
+    expect(wrapper.findComponent({ name: 'UCard' }).exists()).toBe(true)
   })
 
   it('keeps container gutters outside the card surface', async () => {
@@ -71,7 +72,8 @@ describe('WrapGrid (Nuxt runtime)', () => {
     })
     const content = wrapper.find('span')
     const grid = content.element.parentElement
-    const card = grid?.parentElement
+    const cardBody = grid?.parentElement
+    const card = cardBody?.parentElement
     const container = card?.parentElement
 
     expect(grid?.classList.contains('grid')).toBe(true)


### PR DESCRIPTION
## What changed

- renders Layout card mode with Nuxt UI UCard while retaining the branded Stir gradient
- renders the new Text card option with the standard semantic UCard surface
- leaves non-card paragraph markup unchanged
- documents theming ownership and adds runtime coverage

## Why

This makes card presentation reusable and globally themeable through Nuxt UI and app configuration, reducing downstream CSS and avoiding nested layout markup.

## Validation

- full verify:core passed
- 467 coverage tests and 142 Nuxt runtime tests passed
- end-to-end and accessibility suites passed
- lint, type checking, inventory, and production build passed