### PR TITLE
Support contextual media corner styles

### DIFF
--- a/docs/stir-theme-config.md
+++ b/docs/stir-theme-config.md
@@ -526,6 +526,13 @@ intentionally accepts that performance tradeoff. The Drupal media payload
 remains the source of truth for image loading,
 priority, responsive derivatives, dimensions, and quality.
 
+The Media paragraph can also request square corners for a specific placement.
+That contextual choice is passed to visual media only and overrides
+`stirTheme.media.rounded` for that paragraph; leaving it at **Site default**
+continues to use the global theme setting. This keeps reusable Media entities
+free of layout-specific presentation while allowing edge-to-edge imagery to
+render without project CSS.
+
 For repeatable local mobile performance measurements, let the repository build,
 start, warm, verify compression, test, and stop the production server:
 

--- a/layers/theme/app/components/global/Media/Image.vue
+++ b/layers/theme/app/components/global/Media/Image.vue
@@ -39,6 +39,7 @@ const props = defineProps<{
   isHero?: boolean
   wrapperClass?: unknown
   imageClass?: unknown
+  roundedClass?: string
   editActions?: EditAction[]
 }>()
 
@@ -49,6 +50,9 @@ const emit = defineEmits<{
 const appConfig = useAppConfig()
 const runtimeConfig = useRuntimeConfig()
 const theme = appConfig.stirTheme
+const resolvedRoundedClass = computed(() =>
+  props.roundedClass || theme.media.rounded,
+)
 const attrs = useAttrs()
 const forwardedAttrs = computed(() => {
   const {
@@ -220,7 +224,7 @@ onMounted(() => {
           ]
         : [
             theme.media.base,
-            theme.media.rounded,
+            resolvedRoundedClass,
             'm-auto !object-contain',
             !isLoaded && 'bg-elevated text-transparent motion-safe:animate-pulse',
             imageClass,
@@ -246,7 +250,7 @@ onMounted(() => {
     :aria-busy="isSourceDeferred ? 'true' : undefined"
     :class="[
       'media group @container relative block overflow-hidden',
-      theme.media.rounded,
+      resolvedRoundedClass,
       isSourceDeferred && !deferredFrameStyle && 'min-h-64',
       wrapperClass,
     ]"
@@ -263,7 +267,7 @@ onMounted(() => {
       :alt="alt || ''"
       :class="[
         theme.media.base,
-        theme.media.rounded,
+        resolvedRoundedClass,
         platform === 'instagram' ? 'aspect-3/4' : '',
         !isLoaded && 'opacity-0',
         imageClass,
@@ -285,7 +289,7 @@ onMounted(() => {
       :alt="alt || ''"
       :class="[
         theme.media.base,
-        theme.media.rounded,
+        resolvedRoundedClass,
         !isLoaded && 'opacity-0',
         imageClass,
       ]"

--- a/layers/theme/app/components/global/Media/Item.vue
+++ b/layers/theme/app/components/global/Media/Item.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   revealMode?: RevealMode
   deliveryProfile?: string
   overlay?: boolean
+  roundedClass?: string
   editActions?: EditAction[]
   tk: Pick<SlotsToolkit, 'propsOf'>
 }>()
@@ -101,10 +102,15 @@ const revealMotionProps = computed(() =>
   }),
 )
 
+const visualRoundedClass = computed(() =>
+  isDocument.value || isAudio.value ? undefined : props.roundedClass,
+)
+
 const animatedMediaMotionProps = computed<Record<string, unknown>>(() => ({
   ...renderedMediaProps.value,
   ...revealMotionProps.value,
   editActions: props.editActions,
+  roundedClass: visualRoundedClass.value,
   onEditActionSelect: handleEditActionSelect,
 }))
 
@@ -119,6 +125,7 @@ const shouldAnimate = computed(() =>
     v-if="(!overlay || isDocument || isAudio) && !shouldAnimate"
     v-bind="renderedMediaProps"
     :edit-actions="editActions"
+    :rounded-class="visualRoundedClass"
     @edit-action-select="handleEditActionSelect"
   />
 
@@ -133,6 +140,7 @@ const shouldAnimate = computed(() =>
       class="motion-safe:opacity-0"
       v-bind="renderedMediaProps"
       :edit-actions="editActions"
+      :rounded-class="visualRoundedClass"
       @edit-action-select="handleEditActionSelect"
     />
   </RevealMotion>
@@ -157,6 +165,7 @@ const shouldAnimate = computed(() =>
         'group-focus-within:scale-105',
       ]"
       role="button"
+      :rounded-class="visualRoundedClass"
       tabindex="0"
       @click="openOverlay"
       @edit-action-select="handleEditActionSelect"
@@ -169,7 +178,7 @@ const shouldAnimate = computed(() =>
       class="group relative overflow-hidden"
       :class="[
         { 'motion-safe:opacity-0': shouldAnimate },
-        theme.media.rounded,
+        visualRoundedClass || theme.media.rounded,
         'cursor-pointer',
         'grid place-items-center text-white',
         mediaPreviewClasses.overlayBase,
@@ -184,6 +193,7 @@ const shouldAnimate = computed(() =>
       <MediaImage
         v-bind="{ ...mediaProps, hideCredit: true }"
         :edit-actions="editActions"
+        :rounded-class="visualRoundedClass"
         :wrapper-class="[
           mediaPreviewClasses.zoomLayer,
           theme.media.transitions.slow,

--- a/layers/theme/app/components/global/Media/Video.vue
+++ b/layers/theme/app/components/global/Media/Video.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
     pauseWhenHidden?: boolean
     deferEmbed?: boolean
     editActions?: EditAction[]
+    roundedClass?: string
   }>(),
   {
     type: undefined,
@@ -76,11 +77,15 @@ const props = withDefaults(
     pauseWhenHidden: undefined,
     deferEmbed: true,
     editActions: undefined,
+    roundedClass: undefined,
   },
 )
 
 const theme = useAppConfig().stirTheme
 const { media: mediaTheme } = theme
+const resolvedRoundedClass = computed(() =>
+  props.roundedClass || theme.media.rounded,
+)
 const attrs = useAttrs()
 const forwardedAttrs = computed(() => {
   const {
@@ -441,7 +446,7 @@ watch(
       allowfullscreen
       :class="[
         'absolute inset-0 h-full w-full bg-black',
-        theme.media.rounded,
+        resolvedRoundedClass,
       ]"
       :data-mid="mid"
       loading="lazy"
@@ -455,7 +460,7 @@ watch(
       ref="videoElement"
       :class="[
         'absolute inset-0 h-full w-full bg-black object-contain',
-        theme.media.rounded,
+        resolvedRoundedClass,
       ]"
       controls
       playsinline
@@ -471,7 +476,7 @@ watch(
         'group absolute inset-0 z-10 grid h-full w-full place-items-center overflow-hidden bg-black text-white',
         mediaPreviewClasses.overlayBase,
         mediaPreviewClasses.overlayTint40,
-        theme.media.rounded,
+        resolvedRoundedClass,
       ]"
       type="button"
       @click="activateEmbed"

--- a/layers/theme/app/components/global/Paragraph/Media.vue
+++ b/layers/theme/app/components/global/Paragraph/Media.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   spacing?: string
   width?: string
   widthClass?: string
+  cornerStyle?: 'default' | 'square' | string
   align?: string
   direction?: string
   overlay?: boolean | number | string
@@ -36,6 +37,9 @@ const props = defineProps<{
 }>()
 
 const resolvedWidth = computed(() => props.widthClass || props.width || '')
+const roundedClass = computed(() =>
+  props.cornerStyle === 'square' ? 'rounded-none' : undefined,
+)
 const overlayEnabled = computed(
   () => props.overlay === true || props.overlay === 1 || props.overlay === '1',
 )
@@ -160,6 +164,7 @@ onMounted(() => {
           :node="node"
           :overlay="overlayEnabled"
           :reveal-mode="revealMode"
+          :rounded-class="roundedClass"
           :tk="tk"
           @edit-action-select="selectAction"
           @open="openModal"
@@ -185,6 +190,7 @@ onMounted(() => {
           :node="node"
           :overlay="overlayEnabled"
           :reveal-mode="revealMode"
+          :rounded-class="roundedClass"
           :tk="tk"
           @edit-action-select="selectAction"
           @open="openModal"

--- a/tests/nuxt/runtime/MediaImage.nuxt.spec.ts
+++ b/tests/nuxt/runtime/MediaImage.nuxt.spec.ts
@@ -4,6 +4,19 @@ import MediaImage from '../../../layers/theme/app/components/global/Media/Image.
 import { carouselImageDeliverySizesKey } from '../../../layers/theme/app/utils/imageDelivery'
 
 describe('MediaImage (Nuxt runtime)', () => {
+  it('allows a contextual square-corner override', async () => {
+    const wrapper = await mountSuspended(MediaImage, {
+      props: {
+        alt: 'Full-width image',
+        roundedClass: 'rounded-none',
+        src: '/image.webp',
+      },
+    })
+
+    expect(wrapper.get('.media').classes()).toContain('rounded-none')
+    expect(wrapper.get('img').classes()).toContain('rounded-none')
+  })
+
   it('accepts a canonical provider source without leaking it into markup', async () => {
     const wrapper = await mountSuspended(MediaImage, {
       props: {

--- a/tests/nuxt/runtime/MediaItem.nuxt.spec.ts
+++ b/tests/nuxt/runtime/MediaItem.nuxt.spec.ts
@@ -10,6 +10,26 @@ describe('MediaItem (Nuxt runtime)', () => {
     vi.restoreAllMocks()
   })
 
+  it('passes a contextual corner style to visual media', async () => {
+    const wrapper = await mountSuspended(MediaItem, {
+      props: {
+        index: 0,
+        node: h('div'),
+        roundedClass: 'rounded-none',
+        tk: {
+          propsOf: () => ({
+            alt: 'Full-width image',
+            src: '/full-width.webp',
+            type: 'image',
+          }),
+        } as Pick<SlotsToolkit, 'propsOf'>,
+      },
+    })
+
+    expect(wrapper.get('.media').classes()).toContain('rounded-none')
+    expect(wrapper.get('img').classes()).toContain('rounded-none')
+  })
+
   it('keeps revealed media visible when reduced motion is requested', async () => {
     const matchMedia = vi.spyOn(window, 'matchMedia').mockImplementation(
       (query) => ({


### PR DESCRIPTION
## What changed

- consumes the Media paragraph's semantic `cornerStyle` value
- maps `square` to `rounded-none` for image and video renderers
- retains the global `stirTheme.media.rounded` setting for default content
- leaves audio and document presentation unchanged
- adds runtime coverage for direct image and MediaItem rendering

## Why

Projects need contextual square media—especially edge-to-edge imagery—without CSS overrides or changing a reusable asset globally.

## Validation

- full `pnpm verify:ci`
- 467 core tests
- 142 Nuxt runtime tests
- E2E and accessibility suites
- lint, typecheck, production build, consumer build, and packed-consumer validation
