### PR TITLE
Render semantic Text card variants

### DIFF
--- a/layers/theme/app/components/global/Paragraph/Text.vue
+++ b/layers/theme/app/components/global/Paragraph/Text.vue
@@ -10,6 +10,7 @@ const props = defineProps<
   EditableRichTextProps & {
     align?: string
     card?: boolean | string | number
+    cardVariant?: string
     width?: string
     spacing?: string
     region?: string
@@ -34,11 +35,17 @@ const wrapStyles = computed(() =>
   ),
 )
 const isCard = computed(() => resolveBooleanProp(props.card))
+
+const cardVariant = computed(() => {
+  const variants = ['outline', 'solid', 'soft', 'subtle'] as const
+
+  return variants.find((variant) => variant === props.cardVariant) ?? 'outline'
+})
 </script>
 
 <template>
   <WrapDiv :align="align" :styles="wrapStyles">
-    <UCard v-if="isCard" class="h-full">
+    <UCard v-if="isCard" class="h-full" :variant="cardVariant">
       <EditableRichText v-bind="richTextProps" />
     </UCard>
     <EditableRichText v-else v-bind="richTextProps" />

--- a/tests/nuxt/runtime/ParagraphTextCard.nuxt.spec.ts
+++ b/tests/nuxt/runtime/ParagraphTextCard.nuxt.spec.ts
@@ -25,4 +25,32 @@ describe('ParagraphText card presentation', () => {
     expect(wrapper.findComponent({ name: 'UCard' }).exists()).toBe(true)
     expect(wrapper.text()).toContain('Card text')
   })
+
+  it('passes a supported semantic card style to Nuxt UI', async () => {
+    const wrapper = await mountSuspended(ParagraphText, {
+      props: {
+        card: true,
+        cardVariant: 'solid',
+        text: '<p>Solid card text</p>',
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'UCard' }).props('variant')).toBe(
+      'solid',
+    )
+  })
+
+  it('falls back to outline for unsupported values', async () => {
+    const wrapper = await mountSuspended(ParagraphText, {
+      props: {
+        card: true,
+        cardVariant: 'ghost',
+        text: '<p>Safe card text</p>',
+      },
+    })
+
+    expect(wrapper.findComponent({ name: 'UCard' }).props('variant')).toBe(
+      'outline',
+    )
+  })
 })


### PR DESCRIPTION
Passes the CMS-selected semantic card style to UCard with a safe outline fallback, plus runtime coverage.