### PR TITLE
Restore configured CE proxy prefix

### DIFF
--- a/layers/editorial/server/api/paragraph/[paragraphId]/presentation.get.ts
+++ b/layers/editorial/server/api/paragraph/[paragraphId]/presentation.get.ts
@@ -16,7 +16,7 @@ import { parseParagraphId } from '../../../utils/paragraphTextApi'
 
 export default defineEventHandler(async (event) => {
   const paragraphId = parseParagraphId(event.context.params?.paragraphId)
-  const { apiKey, requestTimeoutMs }
+  const { apiKey, ceApiEndpoint, requestTimeoutMs }
     = resolveDrupalCeApiConfig(useRuntimeConfig())
   const cookie = getForwardedCookie(event)
 
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
 
   try {
     const response = await $fetch.raw<ParagraphPresentationResponse>(
-      buildParagraphPresentationPath(paragraphId),
+      buildParagraphPresentationPath(ceApiEndpoint, paragraphId),
       {
         headers: buildDrupalHeaders({ cookie, apiKey }),
         redirect: 'manual',

--- a/layers/editorial/server/api/paragraph/[paragraphId]/presentation.post.ts
+++ b/layers/editorial/server/api/paragraph/[paragraphId]/presentation.post.ts
@@ -35,7 +35,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const values = body.values as PresentationValues
-  const { apiKey, drupalBaseUrl, requestTimeoutMs }
+  const { apiKey, ceApiEndpoint, drupalBaseUrl, requestTimeoutMs }
     = resolveDrupalCeApiConfig(useRuntimeConfig())
   const cookie = getForwardedCookie(event)
 
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
     assertDrupalResponseNotRedirect(csrfResponse)
 
     const response = await $fetch.raw<ParagraphPresentationResponse>(
-      buildParagraphPresentationPath(paragraphId),
+      buildParagraphPresentationPath(ceApiEndpoint, paragraphId),
       {
         method: 'POST',
         body: { values },

--- a/layers/editorial/server/utils/paragraphPresentationApi.ts
+++ b/layers/editorial/server/utils/paragraphPresentationApi.ts
@@ -1,9 +1,10 @@
 import { createError } from 'h3'
 
 export function buildParagraphPresentationPath(
+  ceApiEndpoint: string,
   paragraphId: number,
 ): string {
-  return `/api/drupal-ce/stir-layout-builder/paragraph/${paragraphId}/presentation`
+  return `/api/drupal-ce${ceApiEndpoint}/stir-layout-builder/paragraph/${paragraphId}/presentation`
 }
 
 export function createUpstreamParagraphPresentationError(error: unknown) {

--- a/tests/server/paragraphPresentationApi.spec.ts
+++ b/tests/server/paragraphPresentationApi.spec.ts
@@ -6,8 +6,8 @@ import {
 
 describe('editorial paragraph presentation API policy', () => {
   it('builds the Drupal CE paragraph presentation endpoint', () => {
-    expect(buildParagraphPresentationPath(42)).toBe(
-      '/api/drupal-ce/stir-layout-builder/paragraph/42/presentation',
+    expect(buildParagraphPresentationPath('/ce-api', 42)).toBe(
+      '/api/drupal-ce/ce-api/stir-layout-builder/paragraph/42/presentation',
     )
   })
 


### PR DESCRIPTION
## Summary

- restore the configured CE API prefix for paragraph presentation requests
- keep presentation routing aligned with the established text and view editor proxy paths
- retain the backward-compatible layout edit-link correction

## Evidence

- direct local proxy test: `/api/drupal-ce/ce-api/...` reaches the registered Drupal CE route
- the prefix-free path reaches Drupal's ordinary route and returns 404
- focused lint and presentation API tests pass

This corrects the 404 observed after the earlier automated review suggested removing the CE prefix.
