### PR TITLE
Support plain text field quick editing

### DIFF
--- a/layers/editorial/README.md
+++ b/layers/editorial/README.md
@@ -8,10 +8,12 @@ remains authoritative for authentication, access checks, and the links or
 tasks exposed to Nuxt.
 
 `EditableRichText` accepts an `editTarget` containing `entityType`, `entityId`,
-and `fieldName`. The matching Drupal formatter emits this metadata beside
-single-value formatted-text fields, so node bodies and paragraph text use the
-same editor without bundle-specific endpoints or downstream coercion. The
-legacy paragraph `id` prop remains a compatibility fallback.
+`fieldName`, and an optional `editorMode`. The matching Drupal formatter emits
+this metadata beside single-value text fields, so node strings, node bodies,
+and paragraph text use the same editor without bundle-specific endpoints or
+downstream coercion. Plain fields use a multiline text control while formatted
+fields retain the HTML editor. The legacy paragraph `id` prop remains a
+compatibility fallback.
 
 Paragraph edit controls also expose a compact Nuxt UI presentation editor when
 Drupal includes a `presentationEdit` capability for that exact paragraph. Its

--- a/layers/editorial/app/components/Edit/Text.vue
+++ b/layers/editorial/app/components/Edit/Text.vue
@@ -25,6 +25,8 @@ const editPanelRef = ref<HTMLElement | null>(null)
 const { y } = useWindowScroll()
 
 const sourceTextRef = computed(() => props.sourceText)
+const isPlainText = computed(() => props.editTarget.editorMode === 'plain')
+const plainTextValue = ref(props.sourceText)
 const toolbarClass = 'admin-ui-toolbar sticky top-0 z-10 mb-2 px-2 py-2'
 const shouldShowBubbleToolbar = (payload: {
   view: { hasFocus: () => boolean }
@@ -62,7 +64,9 @@ function closeEditor(event: 'cancel' | 'saved', value = ''): void {
 async function saveInline() {
   if (isSaving.value) return
 
-  const valueToSave = normalizeEditorHtmlForSave(editorValue.value)
+  const valueToSave = isPlainText.value
+    ? plainTextValue.value
+    : normalizeEditorHtmlForSave(editorValue.value)
 
   isSaving.value = true
   resetEditMessages()
@@ -130,6 +134,7 @@ function scrollEditorIntoViewIfNeeded(): void {
 }
 
 onMounted(async () => {
+  plainTextValue.value = sourceTextRef.value
   syncEditorBuffers(sourceTextRef.value)
   await nextTick()
   scrollEditorIntoViewIfNeeded()
@@ -166,7 +171,19 @@ onMounted(async () => {
       ref="editPanelRef"
       class="admin-ui admin-ui-scope admin-ui-panel rounded-lg"
     >
+      <UTextarea
+        v-if="isPlainText"
+        v-model="plainTextValue"
+        :autoresize="true"
+        class="w-full"
+        :rows="8"
+        :ui="{
+          base: 'admin-editor-prose min-h-32 w-full resize-y rounded-lg p-4',
+        }"
+      />
+
       <UEditor
+        v-else
         v-slot="{ editor }"
         v-model="editorValue"
         class="max-h-[60vh] min-h-32 w-full overflow-y-auto rounded-lg"

--- a/layers/theme/app/types/RichText.ts
+++ b/layers/theme/app/types/RichText.ts
@@ -2,6 +2,7 @@ export interface FormattedTextEditTarget {
   entityType: string
   entityId: number | string
   fieldName: string
+  editorMode?: 'formatted' | 'plain'
 }
 
 export interface EditableRichTextProps {

--- a/layers/theme/app/utils/formattedTextEditTarget.ts
+++ b/layers/theme/app/utils/formattedTextEditTarget.ts
@@ -15,6 +15,10 @@ export function normalizeFormattedTextEditTarget(
   const entityType = stringValue(target.entityType ?? target.entity_type)
   const entityId = stringValue(target.entityId ?? target.entity_id)
   const fieldName = stringValue(target.fieldName ?? target.field_name)
+  const editorModeRaw = stringValue(
+    target.editorMode ?? target.editor_mode,
+  )
+  const editorMode = editorModeRaw === 'plain' ? 'plain' : 'formatted'
 
   if (
     !/^[a-z0-9_]+$/.test(entityType)
@@ -24,7 +28,7 @@ export function normalizeFormattedTextEditTarget(
     return null
   }
 
-  return { entityType, entityId, fieldName }
+  return { entityType, entityId, fieldName, editorMode }
 }
 
 export function formattedTextApiPath(

--- a/tests/unit/formattedTextEditTarget.spec.ts
+++ b/tests/unit/formattedTextEditTarget.spec.ts
@@ -10,12 +10,14 @@ describe('formatted text edit targets', () => {
       entity_type: 'node',
       entity_id: '89',
       field_name: 'body',
+      editor_mode: 'plain',
     })
 
     expect(target).toEqual({
       entityType: 'node',
       entityId: '89',
       fieldName: 'body',
+      editorMode: 'plain',
     })
     expect(formattedTextApiPath(target!)).toBe(
       '/api/formatted-text/node/89/body',
@@ -31,6 +33,7 @@ describe('formatted text edit targets', () => {
       entityType: 'paragraph',
       entityId: '168',
       fieldName: 'field_text',
+      editorMode: 'formatted',
     })
   })
 

--- a/tests/utils/layerContract.spec.ts
+++ b/tests/utils/layerContract.spec.ts
@@ -683,6 +683,10 @@ describe('layer contract', () => {
       resolve(rootDir, 'layers/theme/app/components/global/EditableRichText.vue'),
       'utf8',
     )
+    const textEditor = readFileSync(
+      resolve(rootDir, 'layers/editorial/app/components/Edit/Text.vue'),
+      'utf8',
+    )
 
     expect(paragraphText).toContain('<WrapDiv')
     expect(paragraphText).toContain('<EditableRichText')
@@ -701,6 +705,9 @@ describe('layer contract', () => {
     expect(editableRichText).not.toContain('<LazyEditControls')
     expect(editableRichText).not.toContain('sticky top-16')
     expect(editableRichText).not.toContain('<div class="relative">')
+    expect(textEditor).toContain('props.editTarget.editorMode === \'plain\'')
+    expect(textEditor).toContain('<UTextarea')
+    expect(textEditor).toContain('<UEditor')
 
     const layoutArrangement = readFileSync(
       resolve(


### PR DESCRIPTION
## Summary
- render Drupal-declared plain fields with the native Nuxt UI textarea
- retain the rich editor for formatted fields
- normalize and test the reusable editor-mode contract

## Verification
- pnpm verify:ci
- full unit, runtime, E2E, accessibility, typecheck, build, and packed-consumer validation