### PR TITLE
Label the plain text quick editor

### DIFF
--- a/layers/editorial/app/components/Edit/Text.vue
+++ b/layers/editorial/app/components/Edit/Text.vue
@@ -174,6 +174,7 @@ onMounted(async () => {
       <UTextarea
         v-if="isPlainText"
         v-model="plainTextValue"
+        aria-label="Edit text"
         :autoresize="true"
         class="w-full"
         :rows="8"

--- a/tests/utils/layerContract.spec.ts
+++ b/tests/utils/layerContract.spec.ts
@@ -788,6 +788,7 @@ describe('layer contract', () => {
     expect(textEditor).not.toContain(
       ':class="[classes, \'admin-ui admin-ui-scope admin-ui-panel rounded-lg\']"',
     )
+    expect(textEditor).toContain('aria-label="Edit text"')
   })
 
   it('isolates only rich-text controls without wrapping normal output', () => {


### PR DESCRIPTION
## Fix
- give the plain Nuxt UI textarea a programmatic accessible name
- cover the accessible contract

## Verification
- focused contract tests
- lint
- typecheck