### PR TITLE
Refresh inventory for 4.5.0

### DIFF
--- a/docs/vnext/current-inventory.json
+++ b/docs/vnext/current-inventory.json
@@ -2,7 +2,7 @@
   "schemaVersion": 2,
   "package": {
     "name": "nuxtjs-drupal-stir",
-    "version": "4.4.1",
+    "version": "4.5.0",
     "packageManager": "pnpm@10.33.1",
     "engines": {
       "node": "^22.13.0 || ^24.11.0 || >=26.0.0"


### PR DESCRIPTION
## Fix
- synchronize the generated vNext inventory with the released package version

## Verification
- pnpm verify:core