### PR TITLE
Keep release inventory synchronized

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,8 @@
   "release-it": {
     "$schema": "https://unpkg.com/release-it/schema/release-it.json",
     "hooks": {
-      "before:init": "pnpm verify:ci"
+      "before:init": "pnpm verify:ci",
+      "after:bump": "pnpm audit:vnext-inventory"
     },
     "github": {
       "release": true,


### PR DESCRIPTION
## Fix
- regenerate the vNext inventory after release-it bumps the package version and before it creates the release commit
- prevent every future release tag from containing a stale generated inventory

## Verification
- release-it lifecycle confirmed from installed documentation
- pnpm audit:vnext-inventory:check
- pnpm verify:core